### PR TITLE
fix(workflows): update cache-key for nx cache 🗝️ 

### DIFF
--- a/.github/actions/install-deps/action.yml
+++ b/.github/actions/install-deps/action.yml
@@ -11,8 +11,10 @@ runs:
       uses: actions/cache@v3
       with:
         path: tmp/cache
-        key: ${{ runner.os }}-nx
+        key: ${{ runner.os }}-nx-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('libs/**/src/**') }}-${{ hashFiles('apps/**/src/**') }}
         restore-keys: |
+          ${{ runner.os }}-nx-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('libs/**/src/**') }}
+          ${{ runner.os }}-nx-${{ hashFiles('**/package-lock.json') }}
           ${{ runner.os }}-nx
 
     - name: Use the package manager cache if available

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,13 @@ jobs:
       - name: Prepare
         uses: ./.github/actions/install-deps
 
-      - name: 'Run lint,test,build on affected'
+      - name: 'Check affected from main'
+        if: github.event_name == 'pull_request'
         run: npx nx affected --target=lint,test,build --parallel --maxParallel=3 --base=origin/main --head=HEAD
+
+      - name: 'Check affected from last commit'
+        if: github.event_name == 'push'
+        run: npx nx affected --target=lint,test,build --parallel --maxParallel=3 --base=HEAD~1 --head=HEAD
 
   test:
     name: '[Nx] Test All'

--- a/apps/hpb-client/src/app/app.component.spec.ts
+++ b/apps/hpb-client/src/app/app.component.spec.ts
@@ -1,4 +1,4 @@
-import { TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { HpbThemeService } from '@helderberg-pirates-baseball/shared/styles';
 
@@ -7,6 +7,9 @@ import { AppComponent } from './app.component';
 import Mocked = jest.Mocked;
 
 describe('AppComponent', () => {
+  let fixture: ComponentFixture<AppComponent>;
+  let component: AppComponent;
+
   let hpbThemeSpy: Mocked<HpbThemeService>;
 
   beforeEach(async () => {
@@ -22,9 +25,12 @@ describe('AppComponent', () => {
     }).compileComponents();
   });
 
+  beforeEach(() => {
+    fixture = TestBed.createComponent(AppComponent);
+    component = fixture.componentInstance;
+  });
+
   it('should render', () => {
-    const fixture = TestBed.createComponent(AppComponent);
-    fixture.detectChanges();
-    expect(fixture.componentInstance).toBeTruthy();
+    expect(component).toBeTruthy();
   });
 });

--- a/libs/pages/landing/src/lib/landing.component.spec.ts
+++ b/libs/pages/landing/src/lib/landing.component.spec.ts
@@ -3,8 +3,8 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { LandingComponent } from './landing.component';
 
 describe('PagesLandingComponent', () => {
-  let component: LandingComponent;
   let fixture: ComponentFixture<LandingComponent>;
+  let component: LandingComponent;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({

--- a/libs/pages/not-found/src/lib/not-found.component.spec.ts
+++ b/libs/pages/not-found/src/lib/not-found.component.spec.ts
@@ -4,8 +4,8 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { NotFoundComponent } from './not-found.component';
 
 describe('NotFoundComponent', () => {
-  let component: NotFoundComponent;
   let fixture: ComponentFixture<NotFoundComponent>;
+  let component: NotFoundComponent;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({

--- a/libs/shared/styles/src/lib/hpb-theme.service.spec.ts
+++ b/libs/shared/styles/src/lib/hpb-theme.service.spec.ts
@@ -7,7 +7,6 @@ describe('HpbThemeService', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({});
-
     service = TestBed.inject(HpbThemeService);
   });
 

--- a/libs/shared/ui/src/lib/icon-menu/icon-menu.component.spec.ts
+++ b/libs/shared/ui/src/lib/icon-menu/icon-menu.component.spec.ts
@@ -10,10 +10,11 @@ describe('IconMenuComponent', () => {
     await TestBed.configureTestingModule({
       imports: [IconMenuComponent],
     }).compileComponents();
+  });
 
+  beforeEach(() => {
     fixture = TestBed.createComponent(IconMenuComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
   });
 
   it('should create', () => {


### PR DESCRIPTION
## Description 📝

Update key to use hash of package-lock.json, all files under src in libs, then apps. So that cache updated when changes applied.