### PR TITLE
fix(hpb-client): set style for `main` 🔧 

### DIFF
--- a/apps/hpb-client/src/app/app.component.scss
+++ b/apps/hpb-client/src/app/app.component.scss
@@ -1,4 +1,4 @@
-.container {
+:host main {
   display: flex;
   justify-content: center;
   padding: 15px;


### PR DESCRIPTION
## Description 📝

Set style for `main` element, used to replace `.container`