### PR TITLE
fix(workflows): Improve coverage reporting 🧰 

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -48,6 +48,7 @@ jobs:
         uses: codecov/codecov-action@v3.1.4
         if: hashFiles('coverage/**/*') != ''
         with:
+          directory: coverage
           fail_ci_if_error: true
           verbose: true
 

--- a/libs/pages/landing/project.json
+++ b/libs/pages/landing/project.json
@@ -28,6 +28,11 @@
       "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
       "options": {
         "jestConfig": "libs/pages/landing/jest.config.ts"
+      },
+      "configurations": {
+        "ci": {
+          "coverageReporters": ["lcov"]
+        }
       }
     },
     "lint": {

--- a/libs/pages/not-found/project.json
+++ b/libs/pages/not-found/project.json
@@ -28,6 +28,11 @@
       "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
       "options": {
         "jestConfig": "libs/pages/not-found/jest.config.ts"
+      },
+      "configurations": {
+        "ci": {
+          "coverageReporters": ["lcov"]
+        }
       }
     },
     "lint": {


### PR DESCRIPTION
## Description 📝

Updated pages libs to generate coverage reports. And updated codedcov step to only search `coverage` folder for reports (seems to be including cached coverage).